### PR TITLE
Remove depreciated parameters

### DIFF
--- a/hydra-configs-pytorch-lightning/hydra_configs/pytorch_lightning/trainer.py
+++ b/hydra-configs-pytorch-lightning/hydra_configs/pytorch_lightning/trainer.py
@@ -65,6 +65,4 @@ class TrainerConf:
     amp_backend: str = "native"
     amp_level: str = "O2"
     distributed_backend: Optional[str] = None
-    automatic_optimization: Optional[bool] = None
     move_metrics_to_cpu: bool = False
-    enable_pl_optimizer: bool = False


### PR DESCRIPTION
It is impossible to instantiate a `Trainer` without this modification on the new `ptl` version.

See: https://github.com/PyTorchLightning/pytorch-lightning/pull/6163